### PR TITLE
fix tkg-flash compilation on mac osx

### DIFF
--- a/cli/rs232.c
+++ b/cli/rs232.c
@@ -34,7 +34,7 @@
 #include "rs232.h"
 
 
-#if defined(__linux__) || defined(__FreeBSD__)   /* Linux & FreeBSD */
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)   /* OSX, Linux & FreeBSD */
 
 #define RS232_PORTNR  38
 
@@ -103,6 +103,7 @@ int RS232_OpenComport(int comport_number, int baudrate, const char *mode, int fl
                    break;
     case  230400 : baudr = B230400;
                    break;
+#if !defined(__APPLE__)
     case  460800 : baudr = B460800;
                    break;
     case  500000 : baudr = B500000;
@@ -127,6 +128,7 @@ int RS232_OpenComport(int comport_number, int baudrate, const char *mode, int fl
                    break;
     case 4000000 : baudr = B4000000;
                    break;
+#endif
     default      : printf("invalid baudrate\n");
                    return(1);
                    break;

--- a/cli/rs232.h
+++ b/cli/rs232.h
@@ -42,7 +42,7 @@ extern "C" {
 
 
 
-#if defined(__linux__) || defined(__FreeBSD__)
+#if defined(__APPLE__) || defined(__linux__) || defined(__FreeBSD__)
 
 #include <termios.h>
 #include <sys/ioctl.h>


### PR DESCRIPTION
Hi TheKikGen,

Thanks for the excellent USBMidiKliK4x4 thingy! I decided to try it because my cheap chinese adapter didn't work. Since I work on Mac OSX and I do not use arduino for STM32 I needed tgk-flash working. Here is my patch that fixes tgk-flash compilation on Mac OSX.

The bootloader I flashed with J-link. Just in case if you will want to add it to the docs.
> jlinkexe -device stm32f103c8 -speed 8000khz  -if SWD -autoconnect 1
J-Link>r
J-Link>h
J-Link>loadbin tkg_hid_generic_pc13.bin 0x08000000
J-Link>verifybin tkg_hid_generic_pc13.bin 0x08000000
