### PR TITLE
fix(flash): unlock flash unconditionally for clone STM32F103 chips

### DIFF
--- a/F1/Src/flash.c
+++ b/F1/Src/flash.c
@@ -26,13 +26,19 @@ void FLASH_WritePage(uint16_t *page, uint16_t *data, uint16_t size)
 {
 	FLASH_WAIT_COMPLETE;
 
-	// Unlock Flash with magic keys
-	// If already unlocked, do nothing
+	// Clear any pending error/status flags before starting (matches CubeProgrammer
+	// behaviour — required on clone chips that leave PGERR set after failed ops)
+	WRITE_REG(FLASH->SR, FLASH_SR_PGERR | FLASH_SR_WRPRTERR | FLASH_SR_EOP);
 
-	if ( READ_BIT(FLASH->CR, FLASH_CR_LOCK) ) {
-		WRITE_REG(FLASH->KEYR, FLASH_KEY1);
-		WRITE_REG(FLASH->KEYR, FLASH_KEY2);
-	}
+	// Unlock Flash unconditionally.  On certain clone chips FLASH_CR.LOCK reads
+	// as 0 after reset even though the flash controller is still locked in
+	// hardware until the correct key sequence is written to FLASH_KEYR.
+	// The conditional check caused the unlock to be skipped on those devices,
+	// making every subsequent erase/write silently do nothing.
+	// Writing the correct keys when already unlocked is a safe no-op on
+	// genuine STM32F1 silicon (CubeProgrammer does the same thing).
+	WRITE_REG(FLASH->KEYR, FLASH_KEY1);
+	WRITE_REG(FLASH->KEYR, FLASH_KEY2);
 
 	FLASH_WAIT_COMPLETE;
 


### PR DESCRIPTION
On certain clone STM32F103 devices (chips that correctly report DBGMCU_IDCODE = 0x10006412 but have a non-standard flash controller), FLASH_CR.LOCK reads as 0 after reset even though the flash controller is still locked in hardware until the correct key sequence is written to FLASH_KEYR.

The previous conditional unlock:

    if (READ_BIT(FLASH->CR, FLASH_CR_LOCK)) {
        WRITE_REG(FLASH->KEYR, FLASH_KEY1);
        WRITE_REG(FLASH->KEYR, FLASH_KEY2);
    }

silently skipped the unlock sequence on these devices, causing every subsequent erase and write to do nothing.  The bootloader still reported success because the checksum is computed over the received USB data, not the actual flash contents.

Fix: write the unlock keys unconditionally, matching the behaviour of STM32CubeProgrammer's 0x412.stldr flash algorithm, which also writes the keys without checking LOCK first.  Writing the correct keys when the flash is already unlocked is a documented safe no-op on genuine STM32F1 silicon (RM0008 rev 21, section 3.3.3).

Also clear FLASH_SR error flags (PGERR, WRPRTERR, EOP) before each page operation, again matching CubeProgrammer's Init() sequence, to ensure a clean controller state if a previous operation left an error flag set.

Tested on a clone device (DBGMCU_IDCODE 0x10006412, WRPR 0xFFFFFFFF, no read protection) where tkg-flash previously reported "1 sectors written / no checksum error" but left flash completely unprogrammed. After this fix the bootloader programs and jumps to user code correctly.